### PR TITLE
fix: guard ZeroDivisionError, add SIGTERM trap, and address code quality issues

### DIFF
--- a/ovs-collect
+++ b/ovs-collect
@@ -8,7 +8,12 @@ vswitchd_pid=$(pgrep ovs-vswitchd)
 re='^[1-9][0-9]*$'
 
 if [[ ! "$interval" =~ $re ]]; then
-    echo "Interval must a be a positive interger, exiting"
+    echo "Interval must be a positive integer, exiting"
+    exit 1
+fi
+
+if [ -z "$vswitchd_pid" ]; then
+    echo "ERROR: ovs-vswitchd is not running, cannot collect stats"
     exit 1
 fi
 
@@ -43,7 +48,16 @@ appctl_cmds=("dpctl/dump-flows --more --names" "dpctl/ct-stats-show" "dpctl/show
              "coverage/show" "memory/show" "upcall/show" "dpif-netdev/pmd-perf-show")
 target="--target "$ovs_dir"/ovs-vswitchd.$vswitchd_pid.ctl"
 
-while true; do
+has_netdev_datapath=0
+datapath_types=$(ovs-vsctl get Open_vSwitch . datapath_types 2>/dev/null)
+if [[ "$datapath_types" == *"netdev"* ]]; then
+    has_netdev_datapath=1
+fi
+
+shutdown=0
+trap 'shutdown=1' SIGTERM
+
+while [ "$shutdown" -eq 0 ]; do
     for bridge in $bridges; do
         for ofctl_cmd in "${ofctl_cmds[@]}"; do
             ofctl_file=ofctl-`echo $ofctl_cmd | awk '{print $1}' | sed -e sX/X-X`.txt
@@ -56,7 +70,9 @@ while true; do
 
     ## see https://www.openvswitch.org/support/dist-docs/ovs-vswitchd.8.html "DATAPATH FLOW TABLE DEBUGGING COMMANDS"
 
-    ovs-appctl $target dpif-netdev/pmd-stats-clear 2>&1 >> pmd-stats-clear.stdouterr.txt
+    if [ "$has_netdev_datapath" -eq 1 ]; then
+        ovs-appctl $target dpif-netdev/pmd-stats-clear 2>&1 >> pmd-stats-clear.stdouterr.txt
+    fi
     sleep $interval
     for appctl_cmd in "${appctl_cmds[@]}"; do
         appctl_file=appctl-`echo $appctl_cmd | awk '{print $1}' | sed -e sX/X-X`.txt

--- a/ovs-post-process
+++ b/ovs-post-process
@@ -178,6 +178,8 @@ def compute_and_log_stats(br_name: str, new_br_data: dict, old_br_data: dict):
         print("Number of ports changed between measurements on %s" % br_name)
 
     time_delta = new_br_data['timestamp'] - old_br_data['timestamp']
+    if time_delta <= 0:
+        return
     for intf_name in new_br_data.keys():
         if 'timestamp' in intf_name:
             continue
@@ -223,6 +225,8 @@ def appctl_dpif_netdev_pmd_perf_show(filename: str):
                 '^Time:.*$|' +
                 '^  Iterations:.*$|' +
                 '^  - Used TSC cycles:.*$|' +
+                '^  - sleep iterations:.*$|' +
+                '^  Sleep time \\(us\\):.*$|' +
                 '^  Tx batches:.*$|' +
                 '^  Datapath passes:.*$|' +
                 '^$', line):
@@ -330,9 +334,7 @@ def appctl_dpif_netdev_pmd_perf_show(filename: str):
 
                     print('WARNING: ********** could not find match for [' + line + ']')
                 continue
-                print('pmd not defined')
             continue
-            print('epoch_ms not defined')
     finish_samples()
 
 
@@ -471,6 +473,12 @@ def dpctl_datapath_stats(filename: str):
                 curr_lookups_miss = int(pairs[2].split(':')[1])
                 curr_lookups_lost = int(pairs[3].split(':')[1])
 
+                if time_delta_sec <= 0:
+                    prev_lookups_hit = curr_lookups_hit
+                    prev_lookups_miss = curr_lookups_miss
+                    prev_lookups_lost = curr_lookups_lost
+                    continue
+
                 lookups_hit_sample['value'] = (curr_lookups_hit - prev_lookups_hit) / time_delta_sec
                 lookups_miss_sample['value'] = (curr_lookups_miss - prev_lookups_miss) / time_delta_sec
                 lookups_lost_sample['value'] = (curr_lookups_lost - prev_lookups_lost) / time_delta_sec
@@ -499,6 +507,11 @@ def dpctl_datapath_stats(filename: str):
                 curr_masks_hit = int(pairs[1].split(':')[1])
                 curr_masks_total = int(pairs[2].split(':')[1])
 
+                if time_delta_sec <= 0:
+                    prev_masks_hit = curr_masks_hit
+                    prev_masks_total = curr_masks_total
+                    continue
+
                 masks_hit_sample['value'] = (curr_masks_hit - prev_masks_hit) / time_delta_sec
                 masks_total_sample['value'] = (curr_masks_total - prev_masks_total) / time_delta_sec
 
@@ -513,6 +526,10 @@ def dpctl_datapath_stats(filename: str):
                 #  cache: hit:46193519 hit-rate:59.61%
                 pairs = line[2:].split(' ')
                 curr_cache_hit = int(pairs[1].split(':')[1])
+
+                if time_delta_sec <= 0:
+                    prev_cache_hit = curr_cache_hit
+                    continue
 
                 cache_hit_sample['value'] = (curr_cache_hit - prev_cache_hit) / time_delta_sec
                 prev_cache_hit = curr_cache_hit
@@ -658,14 +675,18 @@ def dpctl_dump_flows(filename: str):
                 else:
                     time_stamp = prev_stamp
 
-                dpctl_dump_desc['type'] = 'ufid-new-flows-sec'
-                new_flow_rate = (curr_new_flow - prev_new_flow) / time_delta_sec
-                log_sample(file_id, dpctl_dump_desc, {'counter': 'new-flows-sec'},{'end':end_stamp_ms,'value':new_flow_rate})
-                prev_new_flow = curr_new_flow
+                if time_delta_sec > 0:
+                    begin_stamp_ms = end_stamp_ms - (time_delta_sec * 1000) + 1
 
-                dpctl_dump_desc['type'] = 'ufid-expired-flows-sec'
-                expired_flow_rate = (curr_expired_flow - prev_expired_flow) / time_delta_sec
-                log_sample(file_id, dpctl_dump_desc, {'counter': 'expired-flows-sec'},{'end':end_stamp_ms,'value':expired_flow_rate})
+                    dpctl_dump_desc['type'] = 'ufid-new-flows-sec'
+                    new_flow_rate = (curr_new_flow - prev_new_flow) / time_delta_sec
+                    log_sample(file_id, dpctl_dump_desc, {'counter': 'new-flows-sec'},{'begin':begin_stamp_ms,'end':end_stamp_ms,'value':new_flow_rate})
+
+                    dpctl_dump_desc['type'] = 'ufid-expired-flows-sec'
+                    expired_flow_rate = (curr_expired_flow - prev_expired_flow) / time_delta_sec
+                    log_sample(file_id, dpctl_dump_desc, {'counter': 'expired-flows-sec'},{'begin':begin_stamp_ms,'end':end_stamp_ms,'value':expired_flow_rate})
+
+                prev_new_flow = curr_new_flow
                 prev_expired_flow = curr_expired_flow
 
             elif 'ufid:' in line:
@@ -717,20 +738,24 @@ def dpctl_dump_flows(filename: str):
                 ufid:41f86fcb-5a71-46a1-8a2c-b18ac103ffd9, recirc_id(0x953b99),dp_hash(0/0),skb_priority(0/0),in_port(0707684fc6fdb77),skb_mark(0/0),ct_state(0x2a/0x3f),ct_zone(0/0),ct_mark(0/0),ct_label(0/0x3),eth(src=0a:58:75:0c:67:b1,dst=0a:58:06:cc:5b:0e),eth_type(0x86dd),ipv6(src=fd01:0:0:1::/ffff:ffff:ffff:ffff::,dst=fd01:0:0:2::16,label=0/0,proto=6,tclass=0/0x3,hlimit=64,frag=no),tcp(src=0/0,dst=0/0),tcp_flags(0/0), packets:1, bytes:826, used:4.972s, flags:P., dp:ovs, actions:ct_clear,set(tunnel(tun_id=0x4,ipv6_dst=fc00:1000::6,ttl=64,tp_dst=6081,geneve({class=0x102,type=0x80,len=4,0x30005}),flags(df|csum|key))),set(eth(src=0a:58:7d:50:4d:fc,dst=0a:58:85:e2:e6:5d)),set(ipv6(hlimit=63)),genev_sys_6081
                 ufid:8acc72d6-b3cb-4051-93e3-4d1177a97a0d, recirc_id(0x953be4),dp_hash(0/0),skb_priority(0/0),in_port(6e769d62d8f9785),skb_mark(0/0),ct_state(0x2a/0x3f),ct_zone(0/0),ct_mark(0/0),ct_label(0/0x1),eth(src=00:00:00:00:00:00/00:00:00:00:00:00,dst=0a:58:05:b9:5e:9f),eth_type(0x86dd),ipv6(src=::/::,dst=fd01:0:0:1::25,label=0/0,proto=0/0,tclass=0/0,hlimit=0/0,frag=no), packets:4, bytes:6396, used:3.145s, flags:P., dp:ovs, actions:1b771892fabde8c
                 '''
+                # Since we only want to log samples with 2 data points check if the prev_counts are still unset
+                if ufids[ufid_key]['prev_packet_count'] == -1 and ufids[ufid_key]['prev_byte_count'] == -1:
+                    continue
+
+                if time_delta_sec <= 0:
+                    continue
+
                 # math on packets / bytes
                 packet_rate = (ufids[ufid_key]['curr_packet_count'] - ufids[ufid_key]['prev_packet_count']) / time_delta_sec
                 bytes_to_Gbits = ((ufids[ufid_key]['curr_byte_count'] - ufids[ufid_key]['prev_byte_count']) * 8.0) / float(1_000_000_000)
                 bit_rate = bytes_to_Gbits / time_delta_sec
 
-                # Since we only want to log samples with 2 data points check if the prev_counts are still unset
-                if ufids[ufid_key]['prev_packet_count'] == -1 and ufids[ufid_key]['prev_byte_count'] == -1:
-                    continue
-
                 # log samples
+                begin_stamp_ms = end_stamp_ms - (time_delta_sec * 1000) + 1
                 dpctl_dump_desc['type'] = 'ufid-packets-sec'
-                log_sample(file_id,dpctl_dump_desc,{'id':ufid_key},{'end': end_stamp_ms,'value':packet_rate})
+                log_sample(file_id,dpctl_dump_desc,{'id':ufid_key},{'begin':begin_stamp_ms,'end': end_stamp_ms,'value':packet_rate})
                 dpctl_dump_desc['type'] = 'ufid-Gbps'
-                log_sample(file_id,dpctl_dump_desc,{'id':ufid_key},{'end': end_stamp_ms,'value':bit_rate})
+                log_sample(file_id,dpctl_dump_desc,{'id':ufid_key},{'begin':begin_stamp_ms,'end': end_stamp_ms,'value':bit_rate})
             else:
                 continue
 
@@ -767,6 +792,7 @@ def main():
     upcall_stats_process.join()
     dpctl_dump_process.join()
     pmd_counters_process.join()
+    return 0
 
 if __name__ == '__main__':
     exit(main())

--- a/ovs-start
+++ b/ovs-start
@@ -1,4 +1,6 @@
 #!/bin/bash
+# -*- mode: sh; indent-tabs-mode: nil; sh-basic-offset: 4 -*-
+# vim: autoindent tabstop=4 shiftwidth=4 expandtab softtabstop=4 filetype=bash
 exec >ovs-start-stderrout.txt
 exec 2>&1
 
@@ -49,4 +51,5 @@ if [ -e $ovs_collect ]; then
     echo $ovs_collect_pid >ovs-collect-pid.txt
 else
     echo "$ovs_collect is not present, exiting"
+    exit 1
 fi

--- a/ovs-stop
+++ b/ovs-stop
@@ -1,4 +1,6 @@
 #!/bin/bash
+# -*- mode: sh; indent-tabs-mode: nil; sh-basic-offset: 4 -*-
+# vim: autoindent tabstop=4 shiftwidth=4 expandtab softtabstop=4 filetype=bash
 exec >ovs-stop-stderrout.txt
 exec 2>&1
 
@@ -30,4 +32,7 @@ if [ -f /usr/bin/xz ]; then
     echo "Compressing any ovs data files"
     xz -T 0 ofctl*.txt
     xz -T 0 appctl*.txt
+    if [ -f pmd-stats-clear.stdouterr.txt ]; then
+        xz -T 0 pmd-stats-clear.stdouterr.txt
+    fi
 fi


### PR DESCRIPTION
## Summary

- Fix runtime crashes in ovs-post-process (ZeroDivisionError, KeyError) that blocked CDM indexing
- Add SIGTERM trap to ovs-collect for graceful shutdown when ovs-stop signals termination
- Harden ovs-collect startup validation and guard DPDK-specific commands
- Address code quality issues: dead code removal, typo fix, missing exit codes, modelines

## Changes

**ovs-post-process:**
- Guard `time_delta_sec <= 0` in `dpctl_datapath_stats()`, `dpctl_dump_flows()`, and `compute_and_log_stats()` to prevent ZeroDivisionError when two samples fall within the same truncated second
- Supply explicit `begin` in `dpctl_dump_flows()` `log_sample()` calls to prevent KeyError when a per-ufid metric has only one sample (short-lived flows seen in exactly 2 consecutive intervals)
- Add `sleep iterations` and `Sleep time (us)` to recognized-but-skipped patterns in PMD parser (OVS 3.5 format; eliminates ~3000 warnings/run)
- Remove unreachable `print()` statements after `continue` (dead code)
- Add explicit `return 0` to `main()`

**ovs-collect:**
- Add SIGTERM trap with shutdown flag so the while-loop exits gracefully after completing the current iteration
- Validate `vswitchd_pid` is non-empty before building `--target` path; exit 1 with clear message if `ovs-vswitchd` is not running
- Guard `dpif-netdev/pmd-stats-clear` to only run when netdev datapath is present (DPDK); avoids error noise on kernel-only nodes
- Fix typo: "must a be a positive interger" → "must be a positive integer"

**ovs-start:**
- Add `exit 1` in else branch when ovs-collect binary is missing (previously exited 0)
- Add vim/emacs modelines per project convention

**ovs-stop:**
- Archive `pmd-stats-clear.stdouterr.txt` for DPDK clear verification in run artifacts
- Add vim/emacs modelines per project convention

## Acceptance Criteria Validation

Validated against run [cbe9e9b4-dcca-4526-a50d-594b52861872](http://storage.scalelab.redhat.com/psahoo/PerfTaskLog/Crucible_RUN/trafficgen--2026-06-02_00%3A51%3A58_UTC--cbe9e9b4-dcca-4526-a50d-594b52861872.tar.xz) (trafficgen ASTF short-lived TCP, OVS-DPDK, 595,903 CPS):

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | `dpctl_datapath_stats()` and `dpctl_dump_flows()` guard against `time_delta_sec == 0` | PASS | No ZeroDivisionError in post-process-output.txt; 80 DATE samples processed cleanly |
| 2 | `dpctl_memory_show_process()` uses key-value parsing | PASS | OVS 3.5 `idl-cells-Open_vSwitch:1269 ofconns:4 ...` parsed; 6 metric descriptors produced |
| 3 | Unreachable code after `continue` removed | PASS | Dead `print()` lines removed; no functional change |
| 4 | `main()` returns 0 explicitly | PASS | Clean exit from post-process launcher |
| 5 | `ovs-collect`: SIGTERM trap added | PASS | `ovs-stop` compressed all data files; no partial/corrupt samples in 80-sample dataset |
| 6 | `ovs-collect`: Typo fixed | PASS | Code inspection confirms fix |
| 7 | `ovs-collect`: `vswitchd_pid` validated | PASS | Non-DUT hosts (`ovs-1`, `ovs-3`) exit with `ERROR: ovs-vswitchd is not running` |
| 8 | `ovs-collect`: `pmd-stats-clear` guarded for DPDK | PASS | DUT (`nfv-intel-11`) has `[netdev, system]`; command runs. Non-DPDK hosts skip it |
| 9 | `ovs-start`: `exit 1` when ovs-collect missing | PASS | Code inspection confirms fix |
| 10 | `ovs-start`, `ovs-stop`: modelines added | PASS | Code inspection confirms |
| 11 | No CDM regressions | PASS | All 7 parsers complete without error; 770 total metric descriptors produced (vs 116 previously when `dpctl_dump_flows` crashed) |

### Additional fixes validated (beyond original criteria):

| Fix | Status | Evidence |
|-----|--------|----------|
| `dpctl_dump_flows` KeyError: 'begin' | PASS | `metric-data-dpctl-dump-flows.json` now produced with 654 descriptors (326 ufid-packets-sec + 326 ufid-Gbps + 2 aggregate rates). Previously crashed on short-lived flows. |
| PMD sleep iteration warnings | PASS | Post-process output reduced from ~3000 WARNING lines to 0. Clean 8-line output. |
| `pmd-stats-clear` archive in ovs-stop | PASS | Code correct; file only has content when the clear command errors (diagnostic value). On healthy DPDK nodes the command succeeds silently. |

## Test plan

- [x] Run trafficgen ASTF short-lived TCP workload with OVS-DPDK DUT
- [x] Verify ovs-post-process completes without tracebacks or ZeroDivisionError
- [x] Verify `metric-data-dpctl-dump-flows.json` is produced (was crashing before)
- [x] Verify PMD parser produces 0 warnings (was ~3000 before)
- [x] Verify non-DUT hosts fail fast with clear error when ovs-vswitchd absent
- [x] Verify all other metric files (port-counters, pmd, memory-show, upcall, datapath-stats) still produced
- [x] Python syntax check: `py_compile.compile('ovs-post-process', doraise=True)` passes
- [x] Bash syntax check: `bash -n ovs-collect && bash -n ovs-start && bash -n ovs-stop` passes